### PR TITLE
fix(SummaryApi): properly convert response type

### DIFF
--- a/apis/SummaryApi.ts
+++ b/apis/SummaryApi.ts
@@ -76,7 +76,7 @@ export class SummaryApi extends runtime.BaseAPI {
             query: queryParameters,
         });
 
-        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(BasicSummaryEntryFromJSON));
+        return new runtime.JSONApiResponse(response, (jsonValue) => Object.values(jsonValue).map(BasicSummaryEntryFromJSON));
     }
 
     /**

--- a/dist/apis/SummaryApi.js
+++ b/dist/apis/SummaryApi.js
@@ -80,7 +80,7 @@ class SummaryApi extends runtime.BaseAPI {
             headers: headerParameters,
             query: queryParameters,
         });
-        return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(models_1.BasicSummaryEntryFromJSON));
+        return new runtime.JSONApiResponse(response, (jsonValue) => Object.values(jsonValue).map(models_1.BasicSummaryEntryFromJSON));
     }
     /**
      * Returns basic sums of the users data, like the net worth, spent and earned amounts. It is multi-currency, and is used in Firefly III to populate the dashboard.


### PR DESCRIPTION
The Basic Summary endpoint returns an object, not an array. This updates the transformer for this endpoint to use `Object.values` to account for this behavior.